### PR TITLE
Detect shell and create new profile file when none exists

### DIFF
--- a/helpers/helpers.sh
+++ b/helpers/helpers.sh
@@ -102,6 +102,14 @@ shell_profile() {
       PROFILE="$HOME/.zprofile"
   elif [ -f "$HOME/.zshrc" ]; then
       PROFILE="$HOME/.zshrc"
+  elif [ "$SHELL" == "/bin/bash" ]; then
+      echo "detected bash shell"
+      PROFILE="$HOME/.bashrc"
+      touch $PROFILE
+  elif [ "$SHELL" == "/bin/zsh" ]; then
+      echo "detected zsh shell"
+      PROFILE="$HOME/.zshrc"
+      touch $PROFILE
   fi
 
   if [ -n "$PROFILE" ]; then


### PR DESCRIPTION
New Macs don't appear to have a shell profile file created by default. This PR adds shell detection, and creates a new shell profile file when none already exist on the machine.