### PR TITLE
Homebrew install detection and profile setup fixes

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -64,6 +64,7 @@ fi
 EOF
 )
     echo "${BREWPATH}" >> ${PROFILE}
+    eval $(/opt/homebrew/bin/brew shellenv)
     logC "Homebrew added to PATH"
 else
     logS "Homebrew already in PATH"

--- a/setup.sh
+++ b/setup.sh
@@ -46,7 +46,7 @@ fi
 
 
 # Install Homebrew
-if ! command_exists brew; then
+if ! [ -f /opt/homebrew/bin/brew ]; then
     logN "Installing Homebrew"
     NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     logC "Homebrew installed"


### PR DESCRIPTION
This PR:
- Changes the brew install detection to look for the existence of the brew command by its full path, so if the script fails after the brew install, but before the profile setup step, future runs won't keep trying to install brew.
- Runs `eval $(/opt/homebrew/bin/brew shellenv)` to set up brew for the current shell session in addition to adding brew setup to the profile file for future shell sessions. This allows the script to install and run brew without having to exit and start a new shell.