### PR TITLE
Idempotency fixes for SSH key generation and Git setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 Brewfile.lock.json
+.ssh_key_path
+.git_configured

--- a/setup.sh
+++ b/setup.sh
@@ -114,14 +114,14 @@ DEFAULT_RSA_PATH=~/.ssh/id_rsa
 logN "Where would you like to save your SSH key? (default: ${DEFAULT_RSA_PATH})"
 read -p "Enter path: " RSA_PATH
 
+if [[ -z ${RSA_PATH} ]]; then
+    RSA_PATH=${DEFAULT_RSA_PATH}
+fi
+
 # Check if key already exists
 if [[ -f ${RSA_PATH} ]]; then
     logS "SSH key already exists"
 else
-    if [[ -z ${RSA_PATH} ]]; then
-        RSA_PATH=${DEFAULT_RSA_PATH}
-    fi
-
     while true; do
         logN "Please enter your Pave email to associate with your SSH key?"
         read -p "Enter email: " EMAIL </dev/tty || {

--- a/setup.sh
+++ b/setup.sh
@@ -108,14 +108,19 @@ else
 fi
 
 
-# Setup SSH key
-DEFAULT_RSA_PATH=~/.ssh/id_rsa
+if [[ -f ./.ssh_key_path ]]; then
+    RSA_PATH=$(cat ./.ssh_key_path)
+    logS "Using SSH key previously created at ${RSA_PATH}"
+else
+    # Setup SSH key
+    DEFAULT_RSA_PATH=~/.ssh/id_rsa
 
-logN "Where would you like to save your SSH key? (default: ${DEFAULT_RSA_PATH})"
-read -p "Enter path: " RSA_PATH
+    logN "Where would you like to save your SSH key? (default: ${DEFAULT_RSA_PATH})"
+    read -p "Enter path: " RSA_PATH
 
-if [[ -z ${RSA_PATH} ]]; then
-    RSA_PATH=${DEFAULT_RSA_PATH}
+    if [[ -z ${RSA_PATH} ]]; then
+        RSA_PATH=${DEFAULT_RSA_PATH}
+    fi
 fi
 
 # Check if key already exists
@@ -123,65 +128,67 @@ if [[ -f ${RSA_PATH} ]]; then
     logS "SSH key already exists"
 else
     logN "Generating SSH key"
-    if [[ ! -f ${RSA_PATH} ]]; then
-        while true; do
-            logN "Please enter your Pave email to associate with your SSH key?"
-            read -p "Enter email: " EMAIL </dev/tty || {
-                EMAIL=""
-            }
+    while true; do
+        logN "Please enter your Pave email to associate with your SSH key?"
+        read -p "Enter email: " EMAIL </dev/tty || {
+            EMAIL=""
+        }
 
-            if [[ -z ${EMAIL} ]]; then
-                logA "Email cannot be empty"
-            else
-                break
-            fi
-        done
+        if [[ -z ${EMAIL} ]]; then
+            logA "Email cannot be empty"
+        else
+            break
+        fi
+    done
 
-        ssh-keygen -t rsa -b 4096 -C "${EMAIL}" -f ${RSA_PATH}
-        logC "SSH key generated"
-    else
-        logS "SSH key already exists"
-    fi
+    ssh-keygen -t rsa -b 4096 -C "${EMAIL}" -f ${RSA_PATH}
+    
+    logC "SSH key generated"
+fi
+echo "$RSA_PATH" > ./.ssh_key_path
 
-    # Add SSH key to config
-    touch ~/.ssh/config
-    if ! string_in_file "IdentityFile ${RSA_PATH}" ~/.ssh/config; then
-        echo -e "\n\nHost *\n AddKeysToAgent yes\n IdentityFile $RSA_PATH\n\n" >> ~/.ssh/config
-        logC "SSH config updated"
-    fi
-
-    # Add SSH key to ssh-agent
-    logN "Adding SSH key to ssh-agent"
-    ssh-add -K $RSA_PATH
-    logC "SSH key added to ssh-agent"
+# Add SSH key to config
+touch ~/.ssh/config
+if ! string_in_file "IdentityFile ${RSA_PATH}" ~/.ssh/config; then
+    echo -e "\n\nHost *\n AddKeysToAgent yes\n IdentityFile $RSA_PATH\n\n" >> ~/.ssh/config
+    logC "SSH config updated"
 fi
 
+# Add SSH key to ssh-agent
+logN "Adding SSH key to ssh-agent"
+ssh-add -K $RSA_PATH
+logC "SSH key added to ssh-agent"
 
-# Configure Git and GitHub
-logN "Copying SSH Public Key to clipboard \nUse this key to add to your GitHub account in the next step"
-pbcopy < ${RSA_PATH}.pub
 
-logN $(cat <<EOF
+if [[ -f ./.git_configured ]]; then
+    logS "Git and GitHub configuration already completed. To re-configure, delete .git_configured, and re-run setup.sh."
+else
+    # Configure Git and GitHub
+    logN "Copying SSH Public Key to clipboard \nUse this key to add to your GitHub account in the next step"
+    pbcopy < ${RSA_PATH}.pub
+
+    logN $(cat <<EOF
 Your browser will be opened to a GitHub SSH Keys settings page\n
 You’ll need to paste into the 'Key' field, then click the 'Add SSK Key' button\n
 Then, click 'Enable SSO' for that key.
 EOF
-)
-read -p "Press enter to continue"
+    )
+    read -p "Press enter to continue"
 
-open https://github.com/settings/ssh/new
+    open https://github.com/settings/ssh/new
 
-logN "Configuring Git"
-logN "Enter your display name for Git"
-read -p "Enter name: " GIT_NAME
-git config --global user.name "${GIT_NAME}"
+    logN "Configuring Git"
+    logN "Enter your display name for Git"
+    read -p "Enter name: " GIT_NAME
+    git config --global user.name "${GIT_NAME}"
 
-logN "Enter your email address for Git"
-read -p "Enter email: " GIT_EMAIL
-git config --global user.email "${GIT_EMAIL}"
+    logN "Enter your email address for Git"
+    read -p "Enter email: " GIT_EMAIL
+    git config --global user.email "${GIT_EMAIL}"
 
-logC "Git configured"
-
+    logC "Git configured"
+    echo "true" > ./.git_configured
+fi
 
 # Setup Complete
 logC $(cat <<EOF

--- a/setup.sh
+++ b/setup.sh
@@ -122,21 +122,21 @@ fi
 if [[ -f ${RSA_PATH} ]]; then
     logS "SSH key already exists"
 else
-    while true; do
-        logN "Please enter your Pave email to associate with your SSH key?"
-        read -p "Enter email: " EMAIL </dev/tty || {
-            EMAIL=""
-        }
-
-        if [[ -z ${EMAIL} ]]; then
-            logA "Email cannot be empty"
-        else
-            break
-        fi
-    done
-
     logN "Generating SSH key"
     if [[ ! -f ${RSA_PATH} ]]; then
+        while true; do
+            logN "Please enter your Pave email to associate with your SSH key?"
+            read -p "Enter email: " EMAIL </dev/tty || {
+                EMAIL=""
+            }
+
+            if [[ -z ${EMAIL} ]]; then
+                logA "Email cannot be empty"
+            else
+                break
+            fi
+        done
+
         ssh-keygen -t rsa -b 4096 -C "${EMAIL}" -f ${RSA_PATH}
         logC "SSH key generated"
     else

--- a/setup.sh
+++ b/setup.sh
@@ -152,7 +152,7 @@ else
 
     # Add SSH key to ssh-agent
     logN "Adding SSH key to ssh-agent"
-    ssh-add -K $rsa_path
+    ssh-add -K $RSA_PATH
     logC "SSH key added to ssh-agent"
 fi
 


### PR DESCRIPTION
This allows the script to be run N number of times without prompting to create an SSH key and configure git each time.