### PR TITLE
[Local Dev] Remove podman and other minor tweaks

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,8 +1,5 @@
 brew 'gh'
 brew 'git'
 brew 'jq'
-brew 'podman'
-brew 'podman-compose'
 
 cask 'google-cloud-sdk'
-cask 'podman-desktop'

--- a/helpers/helpers.sh
+++ b/helpers/helpers.sh
@@ -137,7 +137,6 @@ logP() {
 # log notification
 logN() {
   SETUP_STEP="$*"
-  sudo_refresh
   printf -- "\n${YELLOW}%b${NC}\n" "$*"
 }
 


### PR DESCRIPTION
(Encountered as part of [Engineering Onboarding](https://www.notion.so/pavecompensation/Engineering-Onboarding-e6e57e6a71e640b39547e6c3057f5ef3))

Podman seems to be a vestige (see trove-equity/tarmac#17458) that breaks the current local development setup ([example 1](https://pavecompensation.slack.com/archives/C07BWJR3N94/p1749078138143989?thread_ts=1749076554.257909&cid=C07BWJR3N94), [example 2](https://pavecompensation.slack.com/archives/C07BWJR3N94/p1750703591633819?thread_ts=1750702762.204009&cid=C07BWJR3N94)) with:
```
...
COMPLETED: oh-my-zsh and p10k.zsh configured
Error: podman-machine-default: VM does not exist

Setup script experienced an error

Please post the error in #developer-support

!!! Please post the error in #developer-support FAILED
```

Thus, putting up this PR to fix things so no one else in the future will run into this papercut.